### PR TITLE
optional mirrorURl for downloading elasticsearch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,23 @@ build clean-up phase.
 Lastly the regular test task is configured to exclude the tests with the IT suffix - we only wanted to run these in the
 integration tests phase, not with the regular tests.
 
+## Using a download mirror.
+
+If you perfer to download elasticsearch from a mirror, rather than the official site, you can specify a mirror URL for 
+the startElasticsearch task.
+
+```gradle
+    ...
+    startElasticsearch {
+        ...
+         mirrorUrl = "http://my.local.repository/repository/elastic-download/elasticsearch"
+    }
+
+```
+
+This is especially useful if your company uses an internal repository for dependencies and/or has paranoid proxy 
+policies.
+
 # References
 
 - [ElasticSearch](https://www.elastic.co/products/elasticsearch)

--- a/src/main/groovy/cgoit/gradle/elasticsearch/ElasticsearchActions.groovy
+++ b/src/main/groovy/cgoit/gradle/elasticsearch/ElasticsearchActions.groovy
@@ -25,7 +25,7 @@ class ElasticsearchActions {
     File pidFile
 
     ElasticsearchActions(Project project, File toolsDir, String version,
-            String httpScheme, String httpHost, Integer httpPort, File pidFile) {
+                         String httpScheme, String httpHost, Integer httpPort, File pidFile, String mirrorUrl) {
         this.project = project
         this.toolsDir = toolsDir
         this.version = version
@@ -35,6 +35,7 @@ class ElasticsearchActions {
         this.httpHost = httpHost
         this.httpPort = httpPort
         this.pidFile = pidFile
+        this.mirrorUrl = mirrorUrl
     }
 
     boolean isRunning(maxWait = 10) {
@@ -196,26 +197,30 @@ class ElasticsearchActions {
         switch (majorVersion) {
             case 0:
             case 1:
-                linuxUrl = "https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${version}.tar.gz"
-                winUrl = "https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${version}.zip"
+                String downloadBaseUrl = mirrorUrl != null ? mirrorUrl : "https://download.elastic.co/elasticsearch"
+                linuxUrl = downloadBaseUrl + "/elasticsearch/elasticsearch-${version}.tar.gz"
+                winUrl = downloadBaseUrl + "/elasticsearch/elasticsearch-${version}.zip"
                 break
 
             case 2:
-                linuxUrl = "https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/${version}/elasticsearch-${version}.tar.gz"
-                winUrl = "https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/zip/elasticsearch/${version}/elasticsearch-${version}.zip"
+                String downloadBaseUrl = mirrorUrl != null ? mirrorUrl : "https://download.elasticsearch.org/elasticsearch/release"
+                linuxUrl = downloadBaseUrl +"/org/elasticsearch/distribution/tar/elasticsearch/${version}/elasticsearch-${version}.tar.gz"
+                winUrl = downloadBaseUrl +"/org/elasticsearch/distribution/zip/elasticsearch/${version}/elasticsearch-${version}.zip"
                 break
 
         // there are no versions 3 and 4
 
             case 7:
-                linuxUrl = "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${version}-linux-x86_64.tar.gz"
-                winUrl = "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${version}-windows-x86_64.zip"
+                String downloadBaseUrl = mirrorUrl != null ? mirrorUrl : "https://artifacts.elastic.co/downloads/elasticsearch"
+                linuxUrl = downloadBaseUrl + "/elasticsearch-${version}-linux-x86_64.tar.gz"
+                winUrl = downloadBaseUrl + "/elasticsearch-${version}-windows-x86_64.zip"
                 break
 
 
             default: // catches version 5 and up
-                linuxUrl = "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${version}.tar.gz"
-                winUrl = "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${version}.zip"
+                String downloadBaseUrl = mirrorUrl != null ? mirrorUrl : "https://artifacts.elastic.co/downloads/elasticsearch"
+                linuxUrl = downloadBaseUrl + "/elasticsearch-${version}.tar.gz"
+                winUrl = downloadBaseUrl + "/elasticsearch-${version}.zip"
                 break
         }
 

--- a/src/main/groovy/cgoit/gradle/elasticsearch/StartElasticsearchAction.groovy
+++ b/src/main/groovy/cgoit/gradle/elasticsearch/StartElasticsearchAction.groovy
@@ -57,6 +57,10 @@ class StartElasticsearchAction {
     @Optional
     Boolean forceShutdownBeforeStart = Boolean.FALSE
 
+    @Input
+    @Optional
+    String mirrorUrl
+
     private Project project
 
     private AntBuilder ant
@@ -79,7 +83,7 @@ class StartElasticsearchAction {
         File pidFile = new File(toolsDir, 'elastic/elastic.pid')
 
         ElasticsearchActions elastic = new ElasticsearchActions(project, toolsDir,
-                elasticsearchVersion, httpScheme, httpHost, httpPort, pidFile)
+                elasticsearchVersion, httpScheme, httpHost, httpPort, pidFile, mirrorUrl)
 
         elastic.install()
 

--- a/src/main/groovy/cgoit/gradle/elasticsearch/StopElasticsearchAction.groovy
+++ b/src/main/groovy/cgoit/gradle/elasticsearch/StopElasticsearchAction.groovy
@@ -45,10 +45,11 @@ class StopElasticsearchAction {
         httpScheme = httpScheme ?: DEFAULT_ELASTICSEARCH_SCHEME
         httpHost = httpHost ?: DEFAULT_ELASTICSEARCH_HOST
         httpPort = httpPort ?: DEFAULT_ELASTICSEARCH_PORT
+        String mirrorUrl = null;
 
         ElasticsearchActions elastic = new ElasticsearchActions(project, toolsDir,
                 elasticVersion ?: DEFAULT_ELASTICSEARCH_VERSION,
-                httpScheme, httpHost, httpPort, pidFile)
+                httpScheme, httpHost, httpPort, pidFile, mirrorUrl)
 
         if (elastic.isRunning()) {
             elastic.stopRunning()


### PR DESCRIPTION
Add option to specify alternative download location.
Useful for both performance reasons, and in enterprise environments where direct downloads are blocked, and you have to use either proxy or internal repositories.