### PR TITLE
Handle missing ml xpack on ES5

### DIFF
--- a/src/main/groovy/cgoit/gradle/elasticsearch/ElasticsearchActions.groovy
+++ b/src/main/groovy/cgoit/gradle/elasticsearch/ElasticsearchActions.groovy
@@ -251,7 +251,10 @@ class ElasticsearchActions {
             }
             ant.chmod(file: new File("$home/bin/elasticsearch"), perm: "+x")
             ant.chmod(file: new File("$home/bin/plugin"), perm: "+x")
-            ant.chmod(file: new File("$home/modules/x-pack-ml/platform/linux-x86_64/bin/controller"), perm: "+x")
+            def mlController = new File("$home/modules/x-pack-ml/platform/linux-x86_64/bin/controller")
+            if (mlController.exists()) {
+                ant.chmod(file: mlController, perm: "+x")
+            }
         }
 
         new File("$home/version.txt") << "$version"

--- a/src/main/groovy/cgoit/gradle/elasticsearch/StartElasticsearchAction.groovy
+++ b/src/main/groovy/cgoit/gradle/elasticsearch/StartElasticsearchAction.groovy
@@ -77,6 +77,7 @@ class StartElasticsearchAction {
         File tmpDir = new File("$project.buildDir/elastic/tmp")
         logsDir = logsDir ?: new File("$dataDir/logs")
         File pidFile = new File(toolsDir, 'elastic/elastic.pid')
+        File home = new File(toolsDir, "elastic")
 
         ElasticsearchActions elastic = new ElasticsearchActions(project, toolsDir,
                 elasticsearchVersion, httpScheme, httpHost, httpPort, pidFile)
@@ -116,8 +117,12 @@ class StartElasticsearchAction {
                 "${optPrefix}path.data=$dataDir",
                 "${optPrefix}path.repo=$dataDir/repo",
                 "${optPrefix}path.logs=$logsDir",
-                "${optPrefix}xpack.ml.enabled=false"
         ]
+
+        def mlModule = new File("$home/modules/x-pack-ml")
+        if (mlModule.exists()) {
+            command +=  "${optPrefix}xpack.ml.enabled=false"
+        }
 
         println "${CYAN}* elastic:$NORMAL start ElasticSearch with parameters: ${command.toListString()}"
 


### PR DESCRIPTION
ES5 does not have the ml xpack
This fix does not try to change execute permission on the ML controller binary, if it doesnt exist.
Also, it doesnt provide the xpack.ml.enabled option if the modules doesnt exist. (causes ES to fail during startup)